### PR TITLE
Add example workflow file to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ NOTE: A file that matches an include path and an exclude path will be excluded.
 
 A list of file path globs. The list of linted pull request files (minus those removed in the PR) will be checked to be not excluded in all of the specified globs.
 
+### Sample GitHub Actions workflow
+
+```yaml
+name: Regex lint
+on:
+  pull_request:
+
+jobs:
+  regexlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: candidhealth/regex-lint-gh-action@v1.1.2  # or latest version
+        with:
+          file: .github/regex-lint.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # required to list files in PR
+```
+
 ### For Demonstration Purposes
 
 Hello!


### PR DESCRIPTION
I ran into a number of issues while setting up the workflow file that were difficult to debug, and I figured documenting an example might help future users!

The two particular pain points were:

* missing the `GITHUB_TOKEN` secret: this resulted in a very obscure error:

```
Warning: There was an error in run
Error: Not Found
```

it could be worth detecting if `GITHUB_TOKEN` is missing explicitly and logging a better error message, but that's beyond the scope of this PR

* locking to `v1.1.2`

My workflow was set to `v1` but that didn't pick up any of the `global-include-paths` I specified. A workaround now is to lock to exactly the latest version, but it might be worthwhile to push a new version to github actions marketplace so that v1 resolves to the latest v1 version?